### PR TITLE
Allow both Staff/Veteran and Trash specials to be assigned at the same time.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # Automatic Matcher for Anicord Contracts
+
 This is how you got that weird anime assigned to you
 
 ---
@@ -8,17 +9,23 @@ the pool among all users while avoiding matching shows
 they have seen.
 
 Queries made to AniList will be retried on 429
-forever in doubled increments until either a success or
+forever using the minimum wait times returned by their system until either a success or
 an error. Successful requests are cached in `cache/` for 1
 year and the script can safely be re-run.
 
-### Usage:
+## Usage:
+
 - `pip install .`
 - Put the pool of anilist links in `pool.txt`
+  - After each line place a space, pipe, a second space, and then either `S` or `T` to indicate "Staff" (some seasons "Veteran") or "Trash" specials respectively
 - Put the pool of users in `usernames.txt`
+  - After each line place a space, pipe, a second space, and then either `S`, `T`, or `B` to indicate "Staff" (some seasons "Veteran"), "Trash", or "Both" specials respectively
 - Run `main.py`
 
 ### Spring 2024
+
 `data/pool.txt` in the repo contains staff picks for the season
 
-`data/usernames.txt` has been redacted for privacy reasons
+`data/usernames.txt` has been redacted for privacy reasons.
+
+Both of these contain examples of the proper formatting.

--- a/anilist.py
+++ b/anilist.py
@@ -1,65 +1,54 @@
 import sys
 import time
+from collections import defaultdict
 from typing import NamedTuple
 
 import requests
 from mezmorize import Cache
 
+DEFAULT_CONTRACT_TYPE = "S"
+
 
 class User(NamedTuple):
+    """
+    An anicord user.
+    Attributes:
+        username (str): The username of the user.
+        flag (str): Flag for contracts type.
+            Valid values: `S` (for Staff/Veteran Specials), `T` (for Trash Specials), `B` (for Both).
+            The parser will use DEFAULT_CONTRACT_TYPE if a value is not specified in the file.
+        user_id: The users id on Anilist.
+    """
     username: str
     flag: str
     user_id: int
 
 
 class AnilistEntry(NamedTuple):
+    """
+    An entry on Anilist
+    Attributes:
+        item_id (int): The item id on Anilist
+        url (str): Canonical URL of the item.
+        jp_title (str): The title of the item in romaji.
+        en_title (str): The title of the item in English.
+        isAnime: Whether the item is an anime (true) or manga (false).
+        isTrash: Whether the entry is for Trash Specials (true) or Staff/Veteran Specials (false).
+        isLongAnime: Whether the anime is 16+ Episodes, should always be false if isAnime is false.
+    """
+    item_id: int
     url: str
+    jp_title: str
+    en_title: str
+    isAnime: bool
     isTrash: bool
+    isLongAnime: bool
 
 
 # Cache for 1 year because the library hates me
 cache = Cache(CACHE_TYPE='filesystem', CACHE_DIR='cache', CACHE_DEFAULT_TIMEOUT=365 * 24 * 60 * 60)
 
 URL_BASE = 'https://graphql.anilist.co'
-
-
-def _make_request(query: str, variables: dict, timeout_seconds=5):
-    # retry on 429:
-    while True:
-        response = requests.post(url=URL_BASE, json={
-            'query': query,
-            'variables': variables
-        })
-
-        if response.status_code != 429:
-            break
-
-        print(f'429: {response}. Waiting {timeout_seconds} seconds...', file=sys.stderr)
-        time.sleep(timeout_seconds)
-        timeout_seconds *= 2
-
-    return response.json()
-
-
-def _get_all_pages(query, variables, *, query_field='mediaList', _page=0):
-    response = _make_request(query, variables={**variables, 'page': _page})
-
-    # Can make this asynchronous
-    data = response['data']['Page']
-    has_next_page = data['pageInfo']['hasNextPage']
-    query_list = data[query_field]
-
-    if has_next_page:
-        print(f'next {_page}')
-        return list([*query_list, *_get_all_pages(query, variables, _page=_page + 1)])
-
-    return list(query_list)
-
-
-def medialist_to_tuple(media_list):
-    media_list = filter(lambda m: m['status'] != 'PLANNING', media_list)
-    return list(map(lambda m: (m['media']['id'], m['media']['title']['userPreferred'], m['media']['type'], m['media']['episodes']), media_list))
-
 
 GET_USER_LIST_QUERY = """
 query($userName: String, $page: Int) {
@@ -82,11 +71,45 @@ query($userName: String, $page: Int) {
 }
 """
 
+GET_MEDIA_INFORMATION_query = """
+query ($page: Int, $mediaIds: [Int]) {
+  Page(page: $page, perPage: 50) {
+    pageInfo {
+      hasNextPage
+    }
+    media(id_in: $mediaIds) {
+      id
+      siteUrl
+      episodes
+      type
+      title {
+        romaji
+        english
+      }
+    }
+  }
+}
+"""
 
-@cache.memoize()
-def get_user_list(user_name: str) -> list:
-    return medialist_to_tuple(_get_all_pages(query=GET_USER_LIST_QUERY, variables={'userName': user_name}))
-
+#Reducing amount of data pulled to a bare minimum. This is all the data we need to make determinations.
+GET_MEDIA_IN_USERS_LIST_query = """
+query ($page: Int, $userIds: [Int], $mediaIds: [Int]) {
+  Page(page: $page, perPage: 50) {
+    pageInfo {
+      hasNextPage
+    }
+    mediaList(userId_in: $userIds, mediaId_in: $mediaIds) {
+      user {
+        id
+      }
+      status
+      media {
+        id
+      }
+    }
+  }
+}
+"""
 
 GET_USER_ID_QUERY = """
 query($userName: String) {
@@ -96,6 +119,50 @@ query($userName: String) {
 }
 """
 
+def _get_all_pages(query, variables, *, query_field='mediaList', _page=0):
+    response = _make_request(query, variables={**variables, 'page': _page})
+
+    # Can make this asynchronous
+    data = response['data']['Page']
+    has_next_page = data['pageInfo']['hasNextPage']
+    query_list = data[query_field]
+
+    if has_next_page:
+        print(f'next {_page}')
+        return list([*query_list, *_get_all_pages(query, variables, _page=_page + 1)])
+
+    return list(query_list)
+
+def _make_request(query: str, variables: dict):
+    # retry on 429 after time specified in the response:
+    while True:
+        response = requests.post(url=URL_BASE, json={
+            'query': query,
+            'variables': variables
+        })
+
+        if response.status_code != 429:
+            break
+
+        #Per the docs, going over the rate limit leads to a 1-minute timeout. a 429 should also have a `Retry-After` header.
+        #Timeout is set at 61 seconds to ensure that we wait at least the minimum time even if the header doesn't exist.
+        #If the header does exist we'll use the value provided by it.
+        #Both values are padded an extra 2 seconds to make sure we don't end up making the request just before the timeout is lifted.
+        timeout_seconds = 62
+        if "Retry-After" in response.headers:
+            timeout_seconds = int(response.headers["Retry-After"]) + 2
+
+        print(f'429: {response}. Waiting {timeout_seconds} seconds...', file=sys.stderr)
+        time.sleep(timeout_seconds)
+
+    return response.json()
+
+def get_media_users_are_ineligible_for(user_ids: [int], media_ids: [int]) -> defaultdict[int, [int]]:
+    # Sorting for caching
+    return _get_media_users_are_ineligible_for(sorted(user_ids), sorted(media_ids))
+
+def get_media_information(media_ids: [int]):
+    return _get_media_information(sorted(media_ids))
 
 @cache.memoize()
 def get_user_id(user: User) -> int | None:
@@ -110,52 +177,23 @@ def get_user_id(user: User) -> int | None:
     return response['data']['User']['id']
 
 
-GET_MISSING_MEDIA_query = """
-query($page: Int,  $userIds: [Int], $mediaIds: [Int]) {
-  Page(page: $page, perPage: 50) {
-    pageInfo {
-        hasNextPage
-    }
-    mediaList(userId_in: $userIds, mediaId_in: $mediaIds) {
-      user {
-        id
-        name
-      }
-      status
-      media {
-        status
-        id
-        episodes
-        type
-        title {
-          userPreferred
-        }
-      }
-    }
-  }
-}
-"""
-
-
-def get_missing_media(user_ids: [int], media_ids: [int]):
-    # Sorting for caching
-    return _get_missing_media(sorted(user_ids), sorted(media_ids))
+@cache.memoize()
+def _get_media_information(media_ids: [int]):
+    data = _get_all_pages(query=GET_MEDIA_INFORMATION_query, query_field="media", variables={'mediaIds': media_ids})
+    return data
 
 
 @cache.memoize()
-def _get_missing_media(user_ids: [int], media_ids: [int]):
-    data = _get_all_pages(query=GET_MISSING_MEDIA_query, variables={
+def _get_media_users_are_ineligible_for(user_ids: [int], media_ids: [int]) -> defaultdict[int, [int]]:
+    data = _get_all_pages(query=GET_MEDIA_IN_USERS_LIST_query, variables={
         'userIds': user_ids,
         'mediaIds': media_ids
     })
 
-    # Initialize with all user ids.
-    user_dict = {k: [] for k in user_ids}
-
-    for media_list in data:
-        user_dict[media_list['user']['id']].append(media_list)
-
-    for k, v in user_dict.items():
-        user_dict[k] = medialist_to_tuple(v)
+    # Default dicts are great.
+    user_dict = defaultdict(list)
+    for list_item in data:
+        if list_item["status"] != 'PLANNING': continue
+        user_dict[int(list_item['user']['id'])].append(int(list_item['media']['id']))
 
     return user_dict

--- a/anilist.py
+++ b/anilist.py
@@ -157,11 +157,11 @@ def _make_request(query: str, variables: dict):
 
     return response.json()
 
-def get_media_users_are_ineligible_for(user_ids: [int], media_ids: [int]) -> defaultdict[int, [int]]:
+def get_media_users_are_ineligible_for(user_ids: list[int], media_ids: list[int]) -> defaultdict[int, list[int]]:
     # Sorting for caching
     return _get_media_users_are_ineligible_for(sorted(user_ids), sorted(media_ids))
 
-def get_media_information(media_ids: [int]):
+def get_media_information(media_ids: list[int]):
     return _get_media_information(sorted(media_ids))
 
 @cache.memoize()
@@ -178,13 +178,13 @@ def get_user_id(user: User) -> int | None:
 
 
 @cache.memoize()
-def _get_media_information(media_ids: [int]):
+def _get_media_information(media_ids: list[int]):
     data = _get_all_pages(query=GET_MEDIA_INFORMATION_query, query_field="media", variables={'mediaIds': media_ids})
     return data
 
 
 @cache.memoize()
-def _get_media_users_are_ineligible_for(user_ids: [int], media_ids: [int]) -> defaultdict[int, [int]]:
+def _get_media_users_are_ineligible_for(user_ids: list[int], media_ids: list[int]) -> defaultdict[int, list[int]]:
     data = _get_all_pages(query=GET_MEDIA_IN_USERS_LIST_query, variables={
         'userIds': user_ids,
         'mediaIds': media_ids

--- a/anilist.py
+++ b/anilist.py
@@ -12,7 +12,7 @@ class User(NamedTuple):
 
 
 class AnilistEntry(NamedTuple):
-    id: int
+    url: str
     flag: str
 
 
@@ -124,6 +124,7 @@ query($page: Int,  $userIds: [Int], $mediaIds: [Int]) {
       media {
         status
         id
+        episodes
         title {
           userPreferred
         }

--- a/anilist.py
+++ b/anilist.py
@@ -9,11 +9,12 @@ from mezmorize import Cache
 class User(NamedTuple):
     username: str
     flag: str
+    user_id: int
 
 
 class AnilistEntry(NamedTuple):
     url: str
-    flag: str
+    isTrash: bool
 
 
 # Cache for 1 year because the library hates me
@@ -57,7 +58,7 @@ def _get_all_pages(query, variables, *, query_field='mediaList', _page=0):
 
 def medialist_to_tuple(media_list):
     media_list = filter(lambda m: m['status'] != 'PLANNING', media_list)
-    return list(map(lambda m: (m['media']['id'], m['media']['title']['userPreferred']), media_list))
+    return list(map(lambda m: (m['media']['id'], m['media']['title']['userPreferred'], m['media']['type'], m['media']['episodes']), media_list))
 
 
 GET_USER_LIST_QUERY = """
@@ -125,6 +126,7 @@ query($page: Int,  $userIds: [Int], $mediaIds: [Int]) {
         status
         id
         episodes
+        type
         title {
           userPreferred
         }

--- a/anilist.py
+++ b/anilist.py
@@ -1,8 +1,20 @@
 import sys
 import time
+from typing import NamedTuple
 
 import requests
 from mezmorize import Cache
+
+
+class User(NamedTuple):
+    username: str
+    flag: str
+
+
+class AnilistEntry(NamedTuple):
+    id: int
+    flag: str
+
 
 # Cache for 1 year because the library hates me
 cache = Cache(CACHE_TYPE='filesystem', CACHE_DIR='cache', CACHE_DEFAULT_TIMEOUT=365 * 24 * 60 * 60)
@@ -85,13 +97,13 @@ query($userName: String) {
 
 
 @cache.memoize()
-def get_user_id(user_name: str) -> int | None:
+def get_user_id(user: User) -> int | None:
     response = _make_request(query=GET_USER_ID_QUERY, variables={
-        'userName': user_name
+        'userName': user.username
     })
 
     if 'errors' in response and len(response['errors']) != 0:
-        print(f'{user_name} not found ({response})', file=sys.stderr)
+        print(f'{user.username} not found ({response})', file=sys.stderr)
         return None
 
     return response['data']['User']['id']

--- a/anilist.py
+++ b/anilist.py
@@ -51,6 +51,7 @@ class AnilistEntry(AnilistItem):
     isAnime: bool
     isTrash: bool
     isLongAnime: bool
+    episodes: int = 0
 
 
 # Cache for 1 year because the library hates me

--- a/anilist.py
+++ b/anilist.py
@@ -157,7 +157,7 @@ def _make_request(query: str, variables: dict):
 
     return response.json()
 
-def get_media_users_are_ineligible_for(user_ids: list[int], media_ids: list[int]) -> defaultdict[int, list[int]]:
+def get_media_users_are_ineligible_for(user_ids: list[int], media_ids: set[int]) -> defaultdict[int, list[int]]:
     # Sorting for caching
     return _get_media_users_are_ineligible_for(sorted(user_ids), sorted(media_ids))
 

--- a/anilist.py
+++ b/anilist.py
@@ -14,10 +14,14 @@ class AnilistItem:
     id: int
 
     def __hash__(self):
-        return hash(self.id)
+        return self.id
 
     def __eq__(self, other):
-        return self.id == other.id
+        print(other)
+        if isinstance(other, AnilistItem):
+            return self.id == other.id
+        else:
+            return self.id == other
 
 
 @dataclass(frozen=True)
@@ -174,6 +178,9 @@ def _make_request(query: str, variables: dict):
 
 def get_users_media(users: list[User], media: set[AnilistEntry]) -> defaultdict[User, list[AnilistEntry]]:
     # Sorting for caching
+    # TODO: inefficient
+    _user_map = {u.id: u for u in users}
+
     user_ids = [u.id for u in users]
     media_ids = [m.id for m in media]
     data = _get_media_users_are_ineligible_for(sorted(user_ids), sorted(media_ids))
@@ -182,7 +189,8 @@ def get_users_media(users: list[User], media: set[AnilistEntry]) -> defaultdict[
     user_dict = defaultdict(list)
     for list_item in data:
         if list_item["status"] == 'PLANNING': continue
-        user_dict[int(list_item['user']['id'])].append(int(list_item['media']['id']))
+        user_id = list_item['user']['id']
+        user_dict[_user_map[user_id]].append(int(list_item['media']['id']))
 
     return user_dict
 

--- a/anilist.py
+++ b/anilist.py
@@ -201,6 +201,8 @@ def get_media_information(media_ids: list[int]):
 
 @cache.memoize()
 def get_user_id(user_name: str) -> int | None:
+    print(f'Fetching user {user_name}')
+
     response = _make_request(query=GET_USER_ID_QUERY, variables={
         'userName': user_name
     })
@@ -219,6 +221,8 @@ def _get_media_information(media_ids: list[int]):
 
 @cache.memoize()
 def _get_media_users_are_ineligible_for(user_ids: list[int], media_ids: list[int]) -> list:
+    print('Fetching media')
+
     return _get_all_pages(query=GET_MEDIA_IN_USERS_LIST_query, variables={
         'userIds': user_ids,
         'mediaIds': media_ids

--- a/data/pool.txt
+++ b/data/pool.txt
@@ -1,46 +1,46 @@
-https://anilist.co/anime/21355/ReZero-kara-Hajimeru-Isekai-Seikatsu/
-https://anilist.co/manga/30012/BLEACH/
-https://anilist.co/anime/97986/Made-in-Abyss/
-https://anilist.co/anime/99420/Shoujo-Shuumatsu-Ryokou/
-https://anilist.co/manga/86218/Yagate-Kimi-ni-Naru/
-https://anilist.co/manga/43723/Sidonia-no-Kishi/
-https://anilist.co/anime/12191/Smile-Precure
-https://anilist.co/anime/21714/FLIP-FLAPPERS/
-https://anilist.co/anime/6547/Angel-Beats/
-https://anilist.co/manga/116333/Kono-Kaisha-ni-Suki-na-Hito-ga-Imasu
-https://anilist.co/anime/3673/Nijuu-Mensou-no-Musume
-https://anilist.co/manga/118371/Medalist/
-https://anilist.co/anime/101227/Didnt-I-Say-to-Make-My-Abilities-Average-in-the-Next-Life/
-https://anilist.co/anime/20565/Gonna-be-the-TwinTail/
-https://anilist.co/anime/15051/Love-Live-School-idol-project
-https://anilist.co/manga/30002/Berserk
-https://anilist.co/anime/9756/Puella-Magi-Madoka-Magica/
-https://anilist.co/anime/440/Revolutionary-Girl-Utena/
-https://anilist.co/manga/100109/Majo-to-Yajuu
-https://anilist.co/anime/116589/86-EIGHTYSIX/
-https://anilist.co/anime/154587/Sousou-no-Frieren/
-https://anilist.co/anime/140960/SPYFAMILY/
-https://anilist.co/anime/1/Cowboy-Bebop/
-https://anilist.co/anime/99423/Darling-in-the-Franxx/
-https://anilist.co/anime/1575/Code-Geass-Hangyaku-no-Lelouch
-https://anilist.co/anime/21202/Kono-Subarashii-Sekai-ni-Shukufuku-wo/
-https://anilist.co/anime/126403/Link-Click/
-https://anilist.co/anime/116566/Akudama-Drive/
-https://anilist.co/anime/154116/Undead-Unluck/
-https://anilist.co/anime/130591/Sabikui-Bisco/
-https://anilist.co/manga/154349/Youchien-WARS/
-https://anilist.co/anime/161645/Kusuriya-no-Hitorigoto/
-https://anilist.co/anime/10620/The-Future-Diary/
-https://anilist.co/anime/117343/Talentless-Nana/
-https://anilist.co/anime/105334/Fruits-Basket-1st-Season/
-https://anilist.co/manga/70253/Changbaekan-Mal
-https://anilist.co/manga/110473/Insomniacs-After-School/
-https://anilist.co/manga/99065/Ragna-Crimson/
-https://anilist.co/anime/146975/THE-iDOLMSTER-Cinderella-Girls-U149/ 
-https://anilist.co/anime/125447/Thermae-Romae-Novae/
-https://anilist.co/manga/35255/Dengeki-Daisy/
-https://anilist.co/anime/18153/Kyoukai-no-Kanata/
-https://anilist.co/manga/105307/MagMell-Shinkai-Suizokukan/
-https://anilist.co/manga/138816/Showha-Shouten/
-https://anilist.co/anime/1827/Seirei-no-Moribito
-https://anilist.co/anime/239/Gankutsuou
+https://anilist.co/anime/21355/ReZero-kara-Hajimeru-Isekai-Seikatsu/ | S | S
+https://anilist.co/manga/30012/BLEACH/ | S | S
+https://anilist.co/anime/97986/Made-in-Abyss/ | S | S
+https://anilist.co/anime/99420/Shoujo-Shuumatsu-Ryokou/ | S | S
+https://anilist.co/manga/86218/Yagate-Kimi-ni-Naru/ | S
+https://anilist.co/manga/43723/Sidonia-no-Kishi/ | S
+https://anilist.co/anime/12191/Smile-Precure | S
+https://anilist.co/anime/21714/FLIP-FLAPPERS/ | S
+https://anilist.co/anime/6547/Angel-Beats/ | S
+https://anilist.co/manga/116333/Kono-Kaisha-ni-Suki-na-Hito-ga-Imasu | S
+https://anilist.co/anime/3673/Nijuu-Mensou-no-Musume | S
+https://anilist.co/manga/118371/Medalist/ | S
+https://anilist.co/anime/101227/Didnt-I-Say-to-Make-My-Abilities-Average-in-the-Next-Life/ | S
+https://anilist.co/anime/20565/Gonna-be-the-TwinTail/ | S
+https://anilist.co/anime/15051/Love-Live-School-idol-project | S
+https://anilist.co/manga/30002/Berserk | S
+https://anilist.co/anime/9756/Puella-Magi-Madoka-Magica/ | S
+https://anilist.co/anime/440/Revolutionary-Girl-Utena/ | S
+https://anilist.co/manga/100109/Majo-to-Yajuu | S
+https://anilist.co/anime/116589/86-EIGHTYSIX/ | S
+https://anilist.co/anime/154587/Sousou-no-Frieren/ | S
+https://anilist.co/anime/140960/SPYFAMILY/ | S
+https://anilist.co/anime/1/Cowboy-Bebop/ | S
+https://anilist.co/anime/99423/Darling-in-the-Franxx/ | S
+https://anilist.co/anime/1575/Code-Geass-Hangyaku-no-Lelouch | S
+https://anilist.co/anime/21202/Kono-Subarashii-Sekai-ni-Shukufuku-wo/ | S
+https://anilist.co/anime/126403/Link-Click/ | S
+https://anilist.co/anime/116566/Akudama-Drive/ | S
+https://anilist.co/anime/154116/Undead-Unluck/ | S
+https://anilist.co/anime/130591/Sabikui-Bisco/ | S
+https://anilist.co/manga/154349/Youchien-WARS/ | S
+https://anilist.co/anime/161645/Kusuriya-no-Hitorigoto/ | S
+https://anilist.co/anime/10620/The-Future-Diary/ | S
+https://anilist.co/anime/117343/Talentless-Nana/ | S
+https://anilist.co/anime/105334/Fruits-Basket-1st-Season/ | S
+https://anilist.co/manga/70253/Changbaekan-Mal | S
+https://anilist.co/manga/110473/Insomniacs-After-School/ | S
+https://anilist.co/manga/99065/Ragna-Crimson/ | S
+https://anilist.co/anime/146975/THE-iDOLMSTER-Cinderella-Girls-U149/  | S
+https://anilist.co/anime/125447/Thermae-Romae-Novae/ | S
+https://anilist.co/manga/35255/Dengeki-Daisy/ | S
+https://anilist.co/anime/18153/Kyoukai-no-Kanata/ | S
+https://anilist.co/manga/105307/MagMell-Shinkai-Suizokukan/ | S
+https://anilist.co/manga/138816/Showha-Shouten/ | S
+https://anilist.co/anime/1827/Seirei-no-Moribito | S
+https://anilist.co/anime/239/Gankutsuou | S

--- a/data/usernames.txt
+++ b/data/usernames.txt
@@ -1,8 +1,8 @@
-https://anilist.co/user/user0
-https://anilist.co/user/user1
-https://anilist.co/user/user2
-https://anilist.co/user/user3
-https://anilist.co/user/user4
-https://anilist.co/user/user5
-https://anilist.co/user/user6
-https://anilist.co/user/user7
+https://anilist.co/user/user0 | S
+https://anilist.co/user/user1 | T
+https://anilist.co/user/user2 | B
+https://anilist.co/user/user3 | B
+https://anilist.co/user/user4 | B
+https://anilist.co/user/user5 | S
+https://anilist.co/user/user6 | T
+https://anilist.co/user/user7 | S

--- a/main.py
+++ b/main.py
@@ -183,7 +183,7 @@ if __name__ == '__main__':
                     f"{user.username}: \"{media.en_title if media.en_title else media.jp_title}\" {'Anime' if media.is_anime else 'Manga'}")
 
 
-    write_output('data/assigned_staff.csv', users_assigned_staff, contract_type="Staff")
+    write_output('data/assigned_staff.csv', users_assigned_staff, contract_type="Veteran")
     write_output('data/assigned_trash.csv', users_assigned_trash, contract_type="Trash")
 
     print("\n------------------------------------\nStats:\n")

--- a/main.py
+++ b/main.py
@@ -21,7 +21,7 @@ def _parse_file(file_name: Path):
         return data.split('\n')
 
 
-def select_anime(possible_media: [int], is_trash: bool = False) -> int:
+def select_anime(possible_media: list[int], is_trash: bool = False) -> int:
     if len(possible_media) == 0: return -1
     choices = random.choices(list(possible_media), k=len(possible_media))
 
@@ -99,8 +99,8 @@ if __name__ == '__main__':
     trash_media_users_ineligible_for = anilist.get_media_users_are_ineligible_for(user_ids=trash_users, media_ids=trash_anime)
 
     #We can now generate lists for which anime the user _is_ eligible to be selected for.
-    staff_media_users_eligible_for = dict[int, [int]]() #Key is User ID, value is a list of Media IDs that user is eligible to be given.
-    trash_media_users_eligible_for = dict[int, [int]]()
+    staff_media_users_eligible_for = dict[int, list[int]]() #Key is User ID, value is a list of Media IDs that user is eligible to be given.
+    trash_media_users_eligible_for = dict[int, list[int]]()
 
     for u in staff_users:
         staff_media_users_eligible_for[u] = list(special_anime.difference(staff_media_users_ineligible_for[u]))

--- a/main.py
+++ b/main.py
@@ -5,12 +5,14 @@ from collections import defaultdict, OrderedDict
 from pathlib import Path
 
 import anilist
+from anilist import AnilistEntry
 
 USERNAMES_FILE_NAME = Path('./data/usernames.txt')
 POOL_FILE_NAME = Path('./data/pool.txt')
 
-selections = defaultdict(int)
-special_selections = defaultdict(int)
+anilist_media_information = dict[int, AnilistEntry]()
+anilist_users = OrderedDict() # We want to preserve the original insertion order, this means that older anilist users don't have an "advantage"
+staff_selections = defaultdict(int)
 trash_selections = defaultdict(int)
 
 def _parse_file(file_name: Path):
@@ -19,23 +21,50 @@ def _parse_file(file_name: Path):
         return data.split('\n')
 
 
-def select_anime(user_id: int, missing_media, media_list, avoid_long: bool = False, is_trash: bool = False):
-    possible_media = missing_media.difference((x[0] for x in media_list))
+def select_anime(possible_media: [int], is_trash: bool = False) -> int:
+    if len(possible_media) == 0: return -1
     choices = random.choices(list(possible_media), k=len(possible_media))
-    choice = min([(c, trash_selections[c] if is_trash else special_selections[c]) for c in choices], key=lambda x: x[1])
+
+    choice = choices[0]
+    for c in choices[1:]:
+        if is_trash and trash_selections[c] < trash_selections[choice]: choice = c
+        if not is_trash and staff_selections[c] < staff_selections[choice]: choice = c
+
     if is_trash:
-        trash_selections[choice[0]] += 1
-    else :
-        special_selections[choice[0]] += 1
+        trash_selections[choice] += 1
+    else:
+        staff_selections[choice] += 1
     return choice[0]
 
 if __name__ == '__main__':
     anilist_links = _parse_file(POOL_FILE_NAME)
     anilist_usernames_file = _parse_file(USERNAMES_FILE_NAME)
 
-    anilist_usernames = []
+    #Call anilist to get information about the anime we want to watch
+    anilist_isTrash = {} #Look, I know it's not pythonic and all that, but it allows me to save expensive API calls or cycling through the file list again.
+
+    for link in anilist_links:
+        anilistId = int(re.search(r'(?:anime|manga)/(\d+)/', link).group(1))
+        parts = link.partition(" | ")
+        anilist_isTrash[anilistId] = parts[2] == "T"
+
+    anilist_data = anilist.get_media_information(anilist_isTrash.keys())
+
+    for entry in anilist_data:
+        item_id = int(entry["id"]) #Pre-extracting only things that need read multiple times for human readability.
+        isAnime = entry["type"] == "ANIME"
+        isLongAnime = False if not isAnime else entry["episodes"] >= 16
+        anilist_media_information[item_id] = anilist.AnilistEntry(
+            item_id=item_id,
+            url=entry["siteUrl"],
+            jp_title=entry["title"]["romaji"],
+            en_title = entry["title"]["english"],
+            isAnime=isAnime,
+            isLongAnime=isLongAnime,
+            isTrash=anilist_isTrash[item_id])
+
+    #Get user ids for all participating members.
     for u in anilist_usernames_file:
-        # Simpler this way
         us = u.partition(" | ")
         if us[0].lower().startswith('https://'):
             match = re.search(r'(?<=user/)([a-zA-Z0-9]+)/?', u)
@@ -48,66 +77,103 @@ if __name__ == '__main__':
         else:
             match = us[0]
 
-        anilist_usernames.append(anilist.User(match, us[2], anilist.get_user_id(match)))
+        user_id = anilist.get_user_id(match)
+        if user_id is None:
+            print(f'Anilist user not found: {u}', file=sys.stderr)
+            continue
+        anilist_users[user_id] = anilist.User(match, us[2] if us[2] else anilist.DEFAULT_CONTRACT_TYPE, int(user_id))
 
-    # We want to preserve the original insertion order
-    anilist_users = OrderedDict((user_id, u) for u in anilist_usernames if u and (user_id := anilist.get_user_id(u)))
-
-    anilist_media = {}
-
-    for link in anilist_links:
-        anilistId = int(re.search(r'(?:anime|manga)/(\d+)/', link).group(1))
-        parts = link.partition(" | ")
-        anilist_media[anilistId] = anilist.AnilistEntry(parts[0], parts[2] == "T")
+    # We now have the background information to allow us to start assigning anime.
 
     # both_users exists to allow us to do some optimizations around who gets what and disallowing double 2-cours.
-    trash_users = sorted([u.user_id for u in anilist_usernames if u.flag in {"T", "B"}])
-    special_users = sorted([u.user_id for u in anilist_usernames if u.flag in {"S", "B"}])
-    both_users = sorted([u.user_id for u in anilist_usernames if u.flag == "B"])
+    # These are in insertion order because anilist_users is an OrderedDict
+    trash_users = [int(k) for k,v in anilist_users.items() if v.flag in {"T", "B"}]
+    staff_users = [int(k) for k,v in anilist_users.items() if v.flag in {"S", "B"}]
+    both_users = [int(k) for k,v in anilist_users.items() if v.flag == "B"]
 
+    trash_anime = set([k for k, v in anilist_media_information.items() if v.isTrash])
+    special_anime = set([k for k, v in anilist_media_information.items() if not v.isTrash])
 
-    trash_anime = [kvp[0] for kvp in anilist_media.items() if kvp[1].isTrash]
-    special_anime = [kvp[0] for kvp in anilist_media.items() if not kvp[1].isTrash]
-    # Anime users haven't seen
-    users_missing_staff_media = anilist.get_missing_media(user_ids=list(anilist_users.keys()), media_ids=special_anime)
-    users_missing_trash_media = anilist.get_missing_media(user_ids=trash_users, media_ids=trash_anime)
+    # Get the lists of media that the user has seen at least some of on Anilist
+    staff_media_users_ineligible_for = anilist.get_media_users_are_ineligible_for(user_ids=staff_users, media_ids=special_anime)
+    trash_media_users_ineligible_for = anilist.get_media_users_are_ineligible_for(user_ids=trash_users, media_ids=trash_anime)
 
-    users_assigned_specials = {}
-    users_assigned_trash = {}
+    #We can now generate lists for which anime the user _is_ eligible to be selected for.
+    staff_media_users_eligible_for = dict[int, [int]]() #Key is User ID, value is a list of Media IDs that user is eligible to be given.
+    trash_media_users_eligible_for = dict[int, [int]]()
 
-    # Users that signed up for both get priority because Bpen says so.
+    for u in staff_users:
+        staff_media_users_eligible_for[u] = list(special_anime.difference(staff_media_users_ineligible_for[u]))
+
+    for u in trash_users:
+        trash_media_users_eligible_for[u] = list(special_anime.difference(trash_media_users_ineligible_for[u]))
+
+    users_assigned_staff = dict[int, int]() #Key is User ID, Value is media ID, we'll then format the data out of the respective dicts at the end.
+    users_assigned_trash = dict[int, int]()
+
+    # Users that signed up for both get priority because Bpen says so (also because they're most likely to throw the selection balance out of whack).
 
     for user_id in both_users:
+        # First check both lists and see if one of them only contains long shows.
+        # If so, we'll select from that list first, and limit the other half to short shows.
+        # Note: a user can still receive two long shows if that's all they're eligible for.
+
+        elig_short_staff = [int(k) for k in staff_media_users_eligible_for[user_id] if not anilist_media_information[k].isLongAnime]
+        elig_short_trash = [int(k) for k in trash_media_users_eligible_for[user_id] if not anilist_media_information[k].isLongAnime]
+
+        # Flip a coin to see what will get assigned first
         trash_first = random.randint(0, 1) == 1
-        first_anime = None
+        force_two_long = False
+
+        # Override the coin if needed, if they're unlucky enough to be forced into two long shows we'll abide by the coin, not that it really matters
+        # How this works:
+        # If a user has eligible short entries on both sides, we abide by the coin.
+        #   If they pull a short show (or manga) in their first pull it uses their entire list for the second pull as well, they might end up with two short, who knows.
+        #   If they pull a long show on their first pull we reduce the pool to just short shows (and manga) for the second pull.
+        # If a user is going to be forced to have a long show for one type (but has eligible short/manga in the other) we force the pull on the long side first.
+        #   This then means the check for a long show is triggered, and we automatically use the short list on the other one
+        # If a User has no eligible short shows/manga on either side we set the `force_two_long` bool to true. So that when they are assigned their shows it doesn't try to give them nothing on the second one.
+        if len(elig_short_staff) == 0 and len(elig_short_trash) == 0: force_two_long = True
+        elif len(elig_short_staff) == 0: trash_first = False
+        elif len(elig_short_trash) == 0: trash_first = True
+
         if trash_first:
-            first_anime = select_anime(user_id, users_missing_trash_media[])
+            first_anime = select_anime(trash_media_users_eligible_for[user_id], True)
+            users_assigned_trash[user_id] = first_anime
+            second_anime = -1
+            if first_anime != -1 and anilist_media_information[first_anime].isLongAnime and not force_two_long:
+                second_anime = select_anime(elig_short_staff, False)
+            else:
+                second_anime = select_anime(staff_media_users_eligible_for[user_id], False)
+            users_assigned_staff[user_id] = second_anime
+        else:
+            first_anime = select_anime(staff_media_users_eligible_for[user_id], False)
+            users_assigned_staff[user_id] = first_anime
+            second_anime = -1
+            if first_anime != -1 and anilist_media_information[first_anime].isLongAnime and not force_two_long:
+                second_anime = select_anime(elig_short_trash, True)
+            else:
+                second_anime = select_anime(trash_media_users_eligible_for[user_id], True)
+            users_assigned_trash[user_id] = second_anime
 
-    for user_id, media_list in sorted(users_missing_media.items()):
-        possible_media = anilist_media_ids.difference((x[0] for x in media_list))
+    # That's the hard stuff out of the way. Now for the much easier steps of finishing assigning staff/veterans and then trash.
 
-        if len(possible_media) == 0:
-            print(f'{anilist_users[user_id]},*Nothing*')
-            continue
+    for u in staff_users:
+        if u in both_users: continue
+        anime_id = select_anime(staff_media_users_eligible_for[u], False)
+        users_assigned_staff[u] = anime_id
 
-        # Flatten the distribution
-        choices = random.choices(list(possible_media), k=len(possible_media))
-        choice = min([(c, selections[c]) for c in choices], key=lambda x: x[1])
-        selections[choice[0]] += 1
+    for u in trash_users:
+        if u in both_users: continue
+        anime_id = select_anime(trash_media_users_eligible_for[u], True)
+        users_assigned_trash[u] = anime_id
 
-        users_assigned_anime[user_id] = f'{anilist_users[user_id]},{anilist_media[choice[0]]}'
+    anilist_media_information[-1] = anilist.AnilistEntry(-1, "***NOTHING***", "***NOTHING***", "***NOTHING***", False, False, False)
 
-    print('\n'.join(users_assigned_anime.values()))
+    print("\nStaff/Veteran Specials:\n")
+    for user, media in users_assigned_staff.items():
+        print(f"{anilist_users[user].username}: \"{anilist_media_information[media].en_title}\" {'Anime' if anilist_media_information[media].isAnime else 'Manga'}")
 
-    print()
-    print('Stats:')
-
-    sorted_selections = sorted(selections.items(), key=lambda x: x[1], reverse=True)
-    selected_media = [anilist_media[k] for k in selections.keys()]
-
-    for k, c in sorted(selections.items()):
-        print(f'{anilist_media[k]}: {c}')
-
-    print(f'Total: {len(selections)}/{len(anilist_media)}')
-    print('Missing:')
-    print('\n'.join(list(set(anilist_media.values()).difference(selected_media))))
+    print("\n------------------------------------\nTrash Specials:\n")
+    for user, media in users_assigned_trash.items():
+        print(f"{anilist_users[user].username}: \"{anilist_media_information[media].en_title}\" {'Anime' if anilist_media_information[media].isAnime else 'Manga'}")

--- a/main.py
+++ b/main.py
@@ -23,7 +23,8 @@ if __name__ == '__main__':
     anilist_usernames = []
     for u in anilist_usernames_file:
         # Simpler this way
-        if u.lower().startswith('https://'):
+        us = u.partition(" | ")
+        if us[0].lower().startswith('https://'):
             match = re.search(r'(?<=user/)([a-zA-Z0-9]+)/?', u)
 
             if not match:
@@ -32,9 +33,9 @@ if __name__ == '__main__':
 
             match = match.group(1)
         else:
-            match = u
+            match = us[0]
 
-        anilist_usernames.append(match)
+        anilist_usernames.append(anilist.User(match, us[2]))
 
     # We want to preserve the original insertion order
     anilist_users = OrderedDict((user_id, u) for u in anilist_usernames if u and (user_id := anilist.get_user_id(u)))

--- a/main.py
+++ b/main.py
@@ -54,15 +54,19 @@ if __name__ == '__main__':
     for entry in anilist_data:
         item_id = int(entry["id"]) #Pre-extracting only things that need read multiple times for human readability.
         isAnime = entry["type"] == "ANIME"
-        isLongAnime = False if not isAnime else entry["episodes"] >= 16
-        anilist_media_information[item_id] = anilist.AnilistEntry(
-            item_id=item_id,
+        episodes = entry['episodes'] or 18 # TODO
+
+        isLongAnime = False if not isAnime else episodes >= 16
+        anilist_pool.append(AnilistEntry(
+            id=item_id,
             url=entry["siteUrl"],
             jp_title=entry["title"]["romaji"],
-            en_title = entry["title"]["english"],
+            en_title=entry["title"]["english"],
             isAnime=isAnime,
             isLongAnime=isLongAnime,
-            isTrash=anilist_isTrash[item_id])
+            isTrash=anilist_isTrash[item_id],
+            episodes=episodes)
+        )
 
     #Get user ids for all participating members.
     for u in anilist_usernames_file:

--- a/main.py
+++ b/main.py
@@ -190,7 +190,7 @@ if __name__ == '__main__':
             print(anilist_users[u].username)
 
     missing_trash_list = [u for u in users_assigned_trash if users_assigned_trash[u] == -1]
-    print(f"Users not Assigned a trash special: {len(missing_trash_list)}")
+    print(f"\nUsers not Assigned a trash special: {len(missing_trash_list)}")
 
     if len(missing_trash_list) > 0:
         for u in missing_staff_list:
@@ -200,7 +200,6 @@ if __name__ == '__main__':
     print("Staff/Veteran Specials:")
     for a in special_anime:
         print(f"anilist id: {a}, title: {anilist_media_information[a].en_title if anilist_media_information[a].en_title else anilist_media_information[a].jp_title}, count: {staff_selections[a]}")
-    print()
-    print("Trash Specials:")
+    print("\nTrash Specials:")
     for a in trash_anime:
         print(f"{anilist_media_information[a].en_title if anilist_media_information[a].en_title else anilist_media_information[a].jp_title}: {trash_selections[a]}")

--- a/main.py
+++ b/main.py
@@ -9,18 +9,16 @@ from anilist import User, AnilistEntry
 
 # For convenience
 DEFAULT_ANILIST_ENTRY = AnilistEntry(id=-1, url="***NOTHING***", jp_title="***NOTHING***",
-                                             en_title="***NOTHING***", isAnime=False, isTrash=False, isLongAnime=False)
+                                     en_title="***NOTHING***", is_anime=False, is_trash=False)
 
 USERNAMES_FILE_NAME = Path('./data/usernames.txt')
 POOL_FILE_NAME = Path('./data/pool.txt')
 
-# anilist_media_information = dict[int, AnilistEntry](
-#     {-1: DEFAULT_ANILIST_ENTRY}
-# )
 anilist_pool: list[AnilistEntry] = []
-anilist_users = OrderedDict() # We want to preserve the original insertion order, this means that older anilist users don't have an "advantage"
+anilist_users = OrderedDict()  # We want to preserve the original insertion order. This is to help Frazzle copy paste the output
 staff_selections = defaultdict(int)
 trash_selections = defaultdict(int)
+
 
 def _parse_file(file_name: Path):
     with file_name.open(mode='r') as file:
@@ -32,7 +30,7 @@ def select_anime(possible_media: list[AnilistEntry], score_episodes=True) -> Ani
     if len(possible_media) == 0: return DEFAULT_ANILIST_ENTRY
 
     choices = random.choices(list(possible_media), k=len(possible_media))
-    selections = trash_selections if possible_media[0].isTrash else staff_selections
+    selections = trash_selections if possible_media[0].is_trash else staff_selections
 
     # Select the entry with the current lowest number of assignments
     # If score_episodes is set, it will use an alternate scoring system that prioritizes episode count
@@ -49,39 +47,39 @@ def select_anime(possible_media: list[AnilistEntry], score_episodes=True) -> Ani
 
     return choice
 
+
 if __name__ == '__main__':
     anilist_links = _parse_file(POOL_FILE_NAME)
     anilist_usernames_file = _parse_file(USERNAMES_FILE_NAME)
 
-    #Call anilist to get information about the anime we want to watch
-    anilist_isTrash: dict[int, bool] =  {} #Look, I know it's not pythonic and all that, but it allows me to save expensive API calls or cycling through the file list again.
+    # Call anilist to get information about the anime we want to watch
+    anilist_is_trash: dict[
+        int, bool] = {}  # Look, I know it's not pythonic and all that, but it allows me to save expensive API calls or cycling through the file list again.
 
     for link in anilist_links:
         anilistId = int(re.search(r'(?:anime|manga)/(\d+)/', link).group(1))
         parts = link.partition(" | ")
-        anilist_isTrash[anilistId] = parts[2] == "T"
+        anilist_is_trash[anilistId] = parts[2] == "T"
 
-    anilist_data = anilist.get_media_information(list(anilist_isTrash.keys()))
+    anilist_data = anilist.get_media_information(list(anilist_is_trash.keys()))
 
     for entry in anilist_data:
-        item_id = int(entry["id"]) #Pre-extracting only things that need read multiple times for human readability.
-        isAnime = entry["type"] == "ANIME"
+        anilist_id = int(entry["id"])  # Pre-extracting only things that need read multiple times for human readability.
+        is_anime = entry["type"] == "ANIME"
         # Average number of episodes, for manga
-        episodes = entry['episodes'] or 18 # TODO
+        episodes = entry['episodes'] or 18  # TODO
 
-        isLongAnime = False if not isAnime else episodes >= 16
         anilist_pool.append(AnilistEntry(
-            id=item_id,
+            id=anilist_id,
             url=entry["siteUrl"],
             jp_title=entry["title"]["romaji"],
             en_title=entry["title"]["english"],
-            isAnime=isAnime,
-            isLongAnime=isLongAnime,
-            isTrash=anilist_isTrash[item_id],
+            is_anime=is_anime,
+            is_trash=anilist_is_trash[anilist_id],
             episodes=episodes)
         )
 
-    #Get user ids for all participating members.
+    # Get user ids for all participating members.
     for u in anilist_usernames_file:
         us = u.partition(" | ")
         if us[0].lower().startswith('https://'):
@@ -101,7 +99,8 @@ if __name__ == '__main__':
         if user_id is None:
             print(f'Anilist user not found: {u}', file=sys.stderr)
             continue
-        anilist_users[user_id] = anilist.User(id=int(user_id), username=match, flag=us[2] if us[2] else anilist.DEFAULT_CONTRACT_TYPE)
+        anilist_users[user_id] = anilist.User(id=int(user_id), username=match,
+                                              flag=us[2] if us[2] else anilist.DEFAULT_CONTRACT_TYPE)
 
     # We now have the background information to allow us to start assigning anime.
 
@@ -111,8 +110,8 @@ if __name__ == '__main__':
     staff_users = [u for _, u in anilist_users.items() if u.flag in {"S", "B"}]
     both_users = [u for _, u in anilist_users.items() if u.flag == "B"]
 
-    trash_anime = set(filter(lambda m: m.isTrash, anilist_pool))
-    special_anime = set(filter(lambda m: not m.isTrash, anilist_pool))
+    trash_anime = set(filter(lambda m: m.is_trash, anilist_pool))
+    special_anime = set(filter(lambda m: not m.is_trash, anilist_pool))
 
     # Get media present in users' lists
     staff_users_media = anilist.get_users_media(users=staff_users, media=special_anime)
@@ -150,7 +149,7 @@ if __name__ == '__main__':
 
         # Select another random from the other list
         # Not really clean
-        if media_short.isTrash:
+        if media_short.is_trash:
             users_assigned_trash[user] = media_short
             media_other = select_anime(list(eligible_all))
             users_assigned_staff[user] = media_other
@@ -171,11 +170,13 @@ if __name__ == '__main__':
 
     print("\nStaff/Veteran Specials:\n")
     for user, media in users_assigned_staff.items():
-        print(f"{user.username}: \"{media.en_title if media.en_title else media.jp_title}\" {'Anime' if media.isAnime else 'Manga'}")
+        print(
+            f"{user.username}: \"{media.en_title if media.en_title else media.jp_title}\" {'Anime' if media.is_anime else 'Manga'}")
 
     print("\n------------------------------------\nTrash Specials:\n")
     for user, media in users_assigned_trash.items():
-        print(f"{user.username}: \"{media.en_title if media.en_title else media.jp_title}\" {'Anime' if media.isAnime else 'Manga'}")
+        print(
+            f"{user.username}: \"{media.en_title if media.en_title else media.jp_title}\" {'Anime' if media.is_anime else 'Manga'}")
 
     print("\n------------------------------------\nStats:\n")
     missing_staff_list = [u for u in users_assigned_staff if users_assigned_staff[u] == -1]

--- a/main.py
+++ b/main.py
@@ -27,6 +27,7 @@ def select_anime(possible_media: list[int], is_trash: bool = False) -> int:
 
     choice = choices[0]
     for c in choices[1:]:
+        if c == -1: continue
         if is_trash and trash_selections[c] < trash_selections[choice]: choice = c
         if not is_trash and staff_selections[c] < staff_selections[choice]: choice = c
 
@@ -34,7 +35,7 @@ def select_anime(possible_media: list[int], is_trash: bool = False) -> int:
         trash_selections[choice] += 1
     else:
         staff_selections[choice] += 1
-    return choice[0]
+    return choice
 
 if __name__ == '__main__':
     anilist_links = _parse_file(POOL_FILE_NAME)
@@ -77,7 +78,9 @@ if __name__ == '__main__':
         else:
             match = us[0]
 
+        print(f"Getting id for user: {match}")
         user_id = anilist.get_user_id(match)
+        print(f"user_id: {user_id}")
         if user_id is None:
             print(f'Anilist user not found: {u}', file=sys.stderr)
             continue
@@ -172,8 +175,32 @@ if __name__ == '__main__':
 
     print("\nStaff/Veteran Specials:\n")
     for user, media in users_assigned_staff.items():
-        print(f"{anilist_users[user].username}: \"{anilist_media_information[media].en_title}\" {'Anime' if anilist_media_information[media].isAnime else 'Manga'}")
+        print(f"{anilist_users[user].username}: \"{anilist_media_information[media].en_title if anilist_media_information[media].en_title else anilist_media_information[media].jp_title}\" {'Anime' if anilist_media_information[media].isAnime else 'Manga'}")
 
     print("\n------------------------------------\nTrash Specials:\n")
     for user, media in users_assigned_trash.items():
-        print(f"{anilist_users[user].username}: \"{anilist_media_information[media].en_title}\" {'Anime' if anilist_media_information[media].isAnime else 'Manga'}")
+        print(f"{anilist_users[user].username}: \"{anilist_media_information[media].en_title if anilist_media_information[media].en_title else anilist_media_information[media].jp_title}\" {'Anime' if anilist_media_information[media].isAnime else 'Manga'}")
+
+    print("\n------------------------------------\nStats:\n")
+    missing_staff_list = [u for u in users_assigned_staff if users_assigned_staff[u] == -1]
+    print(f"Users not Assigned a staff/veteran special: {len(missing_staff_list)}")
+
+    if len(missing_staff_list) > 0:
+        for u in missing_staff_list:
+            print(anilist_users[u].username)
+
+    missing_trash_list = [u for u in users_assigned_trash if users_assigned_trash[u] == -1]
+    print(f"Users not Assigned a trash special: {len(missing_trash_list)}")
+
+    if len(missing_trash_list) > 0:
+        for u in missing_staff_list:
+            print(anilist_users[u].username)
+
+    print("\n------------------------------------\nAssignment Counts:\n")
+    print("Staff/Veteran Specials:")
+    for a in special_anime:
+        print(f"anilist id: {a}, title: {anilist_media_information[a].en_title if anilist_media_information[a].en_title else anilist_media_information[a].jp_title}, count: {staff_selections[a]}")
+    print()
+    print("Trash Specials:")
+    for a in trash_anime:
+        print(f"{anilist_media_information[a].en_title if anilist_media_information[a].en_title else anilist_media_information[a].jp_title}: {trash_selections[a]}")

--- a/main.py
+++ b/main.py
@@ -39,7 +39,13 @@ if __name__ == '__main__':
 
     # We want to preserve the original insertion order
     anilist_users = OrderedDict((user_id, u) for u in anilist_usernames if u and (user_id := anilist.get_user_id(u)))
-    anilist_media = {int(re.search(r'(?:anime|manga)/(\d+)/', link).group(1)): link for link in anilist_links}
+
+    anilist_media = {}
+
+    for link in anilist_links:
+        anilistId = int(re.search(r'(?:anime|manga)/(\d+)/', link).group(1))
+        parts = link.partition(" | ")
+        anilist_media[anilistId] = anilist.AnilistEntry(parts[0], parts[2])
 
     anilist_media_ids = list(anilist_media.keys())
 

--- a/main.py
+++ b/main.py
@@ -41,14 +41,14 @@ if __name__ == '__main__':
     anilist_usernames_file = _parse_file(USERNAMES_FILE_NAME)
 
     #Call anilist to get information about the anime we want to watch
-    anilist_isTrash = {} #Look, I know it's not pythonic and all that, but it allows me to save expensive API calls or cycling through the file list again.
+    anilist_isTrash: dict[int, bool] =  {} #Look, I know it's not pythonic and all that, but it allows me to save expensive API calls or cycling through the file list again.
 
     for link in anilist_links:
         anilistId = int(re.search(r'(?:anime|manga)/(\d+)/', link).group(1))
         parts = link.partition(" | ")
         anilist_isTrash[anilistId] = parts[2] == "T"
 
-    anilist_data = anilist.get_media_information(anilist_isTrash.keys())
+    anilist_data = anilist.get_media_information(list(anilist_isTrash.keys()))
 
     for entry in anilist_data:
         item_id = int(entry["id"]) #Pre-extracting only things that need read multiple times for human readability.
@@ -99,8 +99,8 @@ if __name__ == '__main__':
     trash_media_users_ineligible_for = anilist.get_media_users_are_ineligible_for(user_ids=trash_users, media_ids=trash_anime)
 
     #We can now generate lists for which anime the user _is_ eligible to be selected for.
-    staff_media_users_eligible_for = dict[int, list[int]]() #Key is User ID, value is a list of Media IDs that user is eligible to be given.
-    trash_media_users_eligible_for = dict[int, list[int]]()
+    staff_media_users_eligible_for: dict[int, list[int]] = {} #Key is User ID, value is a list of Media IDs that user is eligible to be given.
+    trash_media_users_eligible_for: dict[int, list[int]] = {}
 
     for u in staff_users:
         staff_media_users_eligible_for[u] = list(special_anime.difference(staff_media_users_ineligible_for[u]))

--- a/main.py
+++ b/main.py
@@ -119,8 +119,13 @@ if __name__ == '__main__':
     trash_users_media = anilist.get_users_media(users=trash_users, media=trash_anime)
 
     # Eligible selections for staff and trash users
-    staff_users_eligible_media = {u: list(special_anime.difference(staff_users_media[u])) for u in staff_users}
-    trash_users_eligible_media = {u: list(special_anime.difference(trash_users_media[u])) for u in trash_users}
+    # staff_users_eligible_media = {u: list(special_anime.difference(staff_users_media[u])) for u in staff_users}
+    # trash_users_eligible_media = {u: list(trash_anime.difference(trash_users_media[u])) for u in trash_users}
+
+    # Eligible selections for staff and trash users
+    staff_users_eligible_media = {u: [a for a in special_anime if a.id not in staff_users_media[u]] for u in
+                                  staff_users}
+    trash_users_eligible_media = {u: [a for a in trash_anime if a.id not in trash_users_media[u]] for u in trash_users}
 
     # Final assignments
     users_assigned_staff = dict[User, AnilistEntry]()

--- a/main.py
+++ b/main.py
@@ -18,7 +18,7 @@ USERNAMES_FILE_NAME = Path('./data/usernames.txt')
 POOL_FILE_NAME = Path('./data/pool.txt')
 
 anilist_pool: list[AnilistEntry] = []
-anilist_users = OrderedDict()  # We want to preserve the original insertion order. This is to help Frazzle copy paste the output
+anilist_users = OrderedDict()  # We want to preserve the original insertion order. This is to help Frazzle copy-paste the output
 staff_selections = defaultdict(int)
 trash_selections = defaultdict(int)
 
@@ -172,19 +172,19 @@ if __name__ == '__main__':
     print("\nStaff/Veteran Specials:\n")
 
 
-    def write_output(filename: str, assignments: dict[User, AnilistEntry]):
+    def write_output(filename: str, assignments: dict[User, AnilistEntry], contract_type: str = "Staff"):
         with open(filename, 'w', newline='', encoding='utf-8') as csvfile:
             csvwriter = csv.writer(csvfile, quoting=csv.QUOTE_ALL)
-            csvwriter.writerow(['Username', 'Assigned Media', 'Type', 'Anilist Link'])
+            csvwriter.writerow(['Username', 'Assigned Media', 'Media Type', 'Contract Type', 'Anilist Link'])
             for user, media in assignments.items():
                 csvwriter.writerow([user.username, media.en_title if media.en_title else media.jp_title,
-                                    'Anime' if media.is_anime else 'Manga', media.url])
+                                    'Anime' if media.is_anime else 'Manga', contract_type, media.url])
                 print(
                     f"{user.username}: \"{media.en_title if media.en_title else media.jp_title}\" {'Anime' if media.is_anime else 'Manga'}")
 
 
-    write_output('data/assigned_staff.csv', users_assigned_staff)
-    write_output('data/assigned_trash.csv', users_assigned_trash)
+    write_output('data/assigned_staff.csv', users_assigned_staff, contract_type="Staff")
+    write_output('data/assigned_trash.csv', users_assigned_trash, contract_type="Trash")
 
     print("\n------------------------------------\nStats:\n")
     missing_staff_list = [u for u in users_assigned_staff if users_assigned_staff[u] == -1]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,10 +6,11 @@ dependencies = [
   "requests",
   "mezmorize",
 ]
-requires-python = ">=3.8"
+requires-python = ">=3.10"
 
 authors = [
   {name = "kylosus", email = "jokersus.cava@gmail.com"},
+  {name = "Bpendragon", email = "bpendragon@bpendragon.horse"}
 ]
 description = "Automatic AniList matching for Anicord Contracts"
 readme = "README.md"


### PR DESCRIPTION
This re-writes the selector to choose both Staff and Trash Specials at the same time. 

It pays special attention to the users that signed up for both, to avoid assigning them two long (16+ episode) anime series at the same time. 

Each component was tested locally while the code was being written, but not on a large dataset, and never as a full run all at once. 

Please note:

This _also_ changes the required layout of the data files. 