### PR TITLE
Add discord username information

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,11 @@ year and the script can safely be re-run.
 - Put the pool of anilist links in `pool.txt`
   - After each line place a space, pipe, a second space, and then either `S` or `T` to indicate "Staff" (some seasons "Veteran") or "Trash" specials respectively
 - Put the pool of users in `usernames.txt`
-  - After each line place a space, pipe, a second space, and then either `S`, `T`, or `B` to indicate "Staff" (some seasons "Veteran"), "Trash", or "Both" specials respectively
+  - Each row consists of up to 3 columns
+  - Columns are delimited by ` | ` (space, pipe, space)
+  - The first column is required and is the link to the user's anilist profile.
+  - The second column is the user's discord username. It is optional and may be removed entirely, if omitted out it will be blank in the output CSV.
+  - The final column is which contracts they are signed up for, it is optional, but if provided it must be either `S`, `T`, or `B` to indicate "Staff" (some seasons "Veteran"), "Trash", or "Both" specials respectively. If omitted will default to `S`
 - Run `main.py`
 
 ### Spring 2024

--- a/anilist.py
+++ b/anilist.py
@@ -29,14 +29,15 @@ class User(AnilistItem):
     """
     An anicord user.
     Attributes:
-        username (str): The username of the user.
+        username (str): The anilist username of the user.
         flag (str): Flag for contracts type.
             Valid values: `S` (for Staff/Veteran Specials), `T` (for Trash Specials), `B` (for Both).
             The parser will use DEFAULT_CONTRACT_TYPE if a value is not specified in the file.
-        user_id: The users id on Anilist.
+        discord_name (str): The user's discord username.
     """
     username: str
     flag: str
+    discord_name: str
 
 
 @dataclass(frozen=True)

--- a/anilist.py
+++ b/anilist.py
@@ -135,6 +135,15 @@ query($userName: String) {
 }
 """
 
+GET_ANILIST_USERNAME_BY_ID_QUERY = """
+query($userId: Int) {
+  User(id: $userId) {
+    id,
+    name
+  }
+}
+"""
+
 
 def _get_all_pages(query, variables, *, query_field='mediaList', _page=0):
     response = _make_request(query, variables={**variables, 'page': _page})
@@ -173,7 +182,7 @@ def _make_request(query: str, variables: dict):
         print(f'429: {response}. Waiting {timeout_seconds} seconds...', file=sys.stderr)
         time.sleep(timeout_seconds)
 
-    time.sleep(0.7)  # This should _theoretically_ mean we never hit the 429 again.
+    time.sleep(.9)
     return response.json()
 
 
@@ -199,7 +208,6 @@ def get_users_media(users: list[User], media: set[AnilistEntry]) -> defaultdict[
 def get_media_information(media_ids: list[int]):
     return _get_media_information(sorted(media_ids))
 
-
 @cache.memoize()
 def get_user_id(user_name: str) -> int | None:
     print(f'Fetching user {user_name}')
@@ -213,6 +221,20 @@ def get_user_id(user_name: str) -> int | None:
         return None
 
     return response['data']['User']['id']
+
+@cache.memoize()
+def get_anilist_username_by_id(user_id: int) -> (int | None, str | None) :
+    print(f'Fetching user by id {user_id}')
+
+    response = _make_request(query=GET_ANILIST_USERNAME_BY_ID_QUERY, variables={
+        'userId': int(user_id)
+    })
+
+    if 'errors' in response and len(response['errors']) != 0:
+        print(f'{user_id} not found ({response})', file=sys.stderr)
+        return None
+
+    return (response['data']['User']['id'],  response['data']['User']['name']) if int(user_id) == int(response['data']['User']['id']) else (None, None)
 
 
 @cache.memoize()

--- a/main.py
+++ b/main.py
@@ -19,8 +19,8 @@ POOL_FILE_NAME = Path('./data/pool.txt')
 
 anilist_pool: dict[int, AnilistEntry] = {}
 anilist_users = OrderedDict()  # We want to preserve the original insertion order. This is to help Frazzle copy-paste the output
-staff_selections = defaultdict(int)
-trash_selections = defaultdict(int)
+staff_selections: defaultdict[AnilistEntry, int] = defaultdict(int)
+trash_selections: defaultdict[AnilistEntry, int] = defaultdict(int)
 
 
 def _parse_file(file_name: Path):
@@ -31,7 +31,7 @@ def _parse_file(file_name: Path):
 
 def select_anime(possible_media: list[AnilistEntry], is_trash: bool = False) -> AnilistEntry:
     if len(possible_media) == 0: return DEFAULT_ANILIST_ENTRY
-    choices = random.choices(list(possible_media), k=len(possible_media))
+    choices: list[AnilistEntry] = random.choices(list(possible_media), k=len(possible_media))
 
     choice = choices[0]
     for c in choices[1:]:
@@ -78,9 +78,12 @@ if __name__ == '__main__':
 
     # Get user ids for all participating members.
     for u in anilist_usernames_file:
-        us = u.partition(" | ")
+        us = u.split(" | ")
+        match = None
+        flag = None
+        discord_name = None
         if us[0].lower().startswith('https://'):
-            match = re.search(r'(?<=user/)([a-zA-Z0-9]+)/?', u)
+            match = re.search(r'(?<=user/)([a-zA-Z0-9]+)/?', us[0])
 
             if not match:
                 print(f'Not an anilist user: {u}', file=sys.stderr)
@@ -90,12 +93,21 @@ if __name__ == '__main__':
         else:
             match = us[0]
 
+        if len(us) >= 2:
+            if us[1] in ("S", "T", "B"):
+                flag = us[1]
+            else:
+                discord_name = us[1]
+                if len(us) >= 3:
+                    flag = us[2]
+                else:
+                    flag = None
         user_id = anilist.get_user_id(match)
         if user_id is None:
             print(f'Anilist user not found: {u}', file=sys.stderr)
             continue
         anilist_users[user_id] = anilist.User(id=int(user_id), username=match,
-                                              flag=us[2] if us[2] else anilist.DEFAULT_CONTRACT_TYPE)
+                                              flag=flag if flag else anilist.DEFAULT_CONTRACT_TYPE, discord_name=discord_name if discord_name else "")
 
     # We now have the background information to allow us to start assigning anime.
 
@@ -187,7 +199,7 @@ if __name__ == '__main__':
 
     for u in trash_users:
         if u in both_users: continue
-        media = select_anime(trash_users_eligible_media[u])
+        media = select_anime(trash_users_eligible_media[u], is_trash=True)
         users_assigned_trash[u] = media
 
     print("\nStaff/Veteran Specials:\n")
@@ -196,9 +208,9 @@ if __name__ == '__main__':
     def write_output(filename: str, assignments: dict[User, AnilistEntry], contract_type: str = "Staff"):
         with open(filename, 'w', newline='', encoding='utf-8') as csvfile:
             csvwriter = csv.writer(csvfile, quoting=csv.QUOTE_ALL)
-            csvwriter.writerow(['Username', 'Assigned Media', 'Media Type', 'Contract Type', 'Anilist Link'])
+            csvwriter.writerow(['Anilist Username', 'Discord Username', 'Assigned Media', 'Media Type', 'Contract Type', 'Anilist Link'])
             for user, media in assignments.items():
-                csvwriter.writerow([user.username, media.en_title if media.en_title else media.jp_title,
+                csvwriter.writerow([user.username, user.discord_name, media.en_title if media.en_title else media.jp_title,
                                     'Anime' if media.is_anime else 'Manga', contract_type, media.url])
                 print(
                     f"{user.username}: \"{media.en_title if media.en_title else media.jp_title}\" {'Anime' if media.is_anime else 'Manga'}")

--- a/main.py
+++ b/main.py
@@ -4,7 +4,6 @@ import sys
 import warnings
 import csv
 from collections import defaultdict, OrderedDict
-from os import write
 from pathlib import Path
 
 import anilist
@@ -51,11 +50,11 @@ if __name__ == '__main__':
     anilist_usernames_file = _parse_file(USERNAMES_FILE_NAME)
 
     # Call anilist to get information about the anime we want to watch
-    anilist_is_trash: dict[
-        int, bool] = {}  # Look, I know it's not pythonic and all that, but it allows me to save expensive API calls or cycling through the file list again.
+    anilist_is_trash: dict[int, bool] = {}  # Look, I know it's not pythonic and all that, but it allows me to save expensive API calls or cycling through the file list again.
 
     for link in anilist_links:
-        anilistId = int(re.search(r'(?:anime|manga)/(\d+)/', link).group(1))
+        print(f'Collecting information on {link}')
+        anilistId = int(re.search(r'(?:anime|manga)/(\d+)/?', link).group(1))
         parts = link.partition(" | ")
         anilist_is_trash[anilistId] = parts[2] == "T"
 
@@ -79,9 +78,14 @@ if __name__ == '__main__':
     # Get user ids for all participating members.
     for u in anilist_usernames_file:
         us = u.split(" | ")
-        match = None
+
+        #Items needed for the dictionary
+        alist_uname = None
         flag = None
         discord_name = None
+        user_id = None
+
+        #Extract anilist username from URL
         if us[0].lower().startswith('https://'):
             match = re.search(r'(?<=user/)([a-zA-Z0-9]+)/?', us[0])
 
@@ -89,10 +93,12 @@ if __name__ == '__main__':
                 print(f'Not an anilist user: {u}', file=sys.stderr)
                 continue
 
-            match = match.group(1)
-        else:
-            match = us[0]
+            alist_uname = match.group(1)
 
+        else: #URL not provided, assume they just gave us a username
+            alist_uname = us[0]
+
+        # Extract discord username and contract type(s) to assign
         if len(us) >= 2:
             if us[1] in ("S", "T", "B"):
                 flag = us[1]
@@ -102,11 +108,17 @@ if __name__ == '__main__':
                     flag = us[2]
                 else:
                     flag = None
-        user_id = anilist.get_user_id(match)
+
+        if alist_uname.isdigit(): #Anilist usernames must not be purely numeric, if the match is purely numeric we should confirm the user_id exists and pull their anilist username
+            (user_id, alist_uname) = anilist.get_anilist_username_by_id(alist_uname)
+            print(f'Anilist Username found for id {user_id}: {alist_uname}')
+        else: #If an actual username was provided, pull their user_id
+            user_id = anilist.get_user_id(alist_uname)
+            print(f'Anilist User id found for username {alist_uname}: {user_id}')
         if user_id is None:
             print(f'Anilist user not found: {u}', file=sys.stderr)
             continue
-        anilist_users[user_id] = anilist.User(id=int(user_id), username=match,
+        anilist_users[user_id] = anilist.User(id=int(user_id), username=alist_uname,
                                               flag=flag if flag else anilist.DEFAULT_CONTRACT_TYPE, discord_name=discord_name if discord_name else "")
 
     # We now have the background information to allow us to start assigning anime.


### PR DESCRIPTION
Adds an optional column to the usernames.txt file for the discord username. This was requested by MadFigs because sometimes discord and anilist usernames do not correlate at all making this easier on the admins.